### PR TITLE
Fix PEP timelines (sync from epiworld #253)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,11 @@
 
 * The function `InterventionMeaslesPEP()` implements post-exposure prophylaxis featuring both MMR and IG. The process is highly configurable and can be attached to the `ModelMeaslesSchool()`. Not available yet for other models.
 
-* Fixed the PEP timelines: eligibility for MMR/IG is now a class-level decision based on the last time the class was exposed to the infectious index case (from contact tracing) relative to the day the case is detected, i.e. whether there is still time to intervene. Previously the `mmr_window`/`ig_window` were compared against the index case's infectious-onset date and gated on the specific day a classmate contacted the index, so realistic windows (e.g. `mmr_window = 3`) did not behave as intended.
+* Fixed the PEP timelines. `mmr_window`/`ig_window` are now measured from the exposure to the day the case is identified, i.e. whether there is still time to intervene. The reference date is the *first* day the school encountered the index case on or after its infectious-onset date (rash onset minus the prodromal period); contact tracing is used only to date that first encounter, so if the contact rate is zeroed out on some days (e.g. weekends, via a global event) the first day actually in session anchors the window. When several cases are identified on the same day, the earliest of those first encounters applies. Previously the windows were compared against the index case's infectious-onset date and gated on the specific day a given classmate met the index, so realistic windows (e.g. `mmr_window = 3`) did not behave as intended.
+
+* PEP is now offered to the whole school rather than only to the index case's recorded contacts, reflecting that public health treats the exposed group as exposed rather than tracing individual contacts. Agents already holding a PEP tool are not dosed again (IG still wanes, after which they become eligible once more). Note this makes PEP considerably more widely administered than in previous versions, and outbreak sizes correspondingly smaller.
+
+* Fixed PEP being re-administered every day after a case was identified. The set of triggering cases was only refreshed when a new case was detected, so on quiet days the intervention kept responding to an old detection.
 
 * The models `ModelMeaslesMixing()` and `ModelMeaslesMixingRiskQuarantine()` no longer use `contact_rate`; instead, their `contact_matrix` stores the expected number of contacts between groups. Calibration can now be done with the new function `calibrate_mixing_model()`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * PEP is now offered to the whole school rather than only to the index case's recorded contacts, reflecting that public health treats the exposed group as exposed rather than tracing individual contacts. Agents already holding a PEP tool are not dosed again (IG still wanes, after which they become eligible once more). Note this makes PEP considerably more widely administered than in previous versions, and outbreak sizes correspondingly smaller.
 
+* `InterventionMeaslesPEP()` gains an optional `agent_groups` argument for circumscribing that exposed group. Offering PEP to the entire population is appropriate for a single classroom but misleading when the population is really a set of separate communities. Supplying one group label per agent (e.g. `agent_groups = rep(1:3, each = 20)`) restricts the offer to the group(s) of the identified case(s), and dates each group's window from its own exposure, so a case identified in one classroom no longer shortens the window available to another. The default, `integer(0)`, keeps the whole-population behavior.
+
 * Fixed PEP being re-administered every day after a case was identified. The set of triggering cases was only refreshed when a new case was detected, so on quiet days the intervention kept responding to an old detection.
 
 * The models `ModelMeaslesMixing()` and `ModelMeaslesMixingRiskQuarantine()` no longer use `contact_rate`; instead, their `contact_matrix` stores the expected number of contacts between groups. Calibration can now be done with the new function `calibrate_mixing_model()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * The function `InterventionMeaslesPEP()` implements post-exposure prophylaxis featuring both MMR and IG. The process is highly configurable and can be attached to the `ModelMeaslesSchool()`. Not available yet for other models.
 
+* Fixed the PEP timelines: eligibility for MMR/IG is now a class-level decision based on the last time the class was exposed to the infectious index case (from contact tracing) relative to the day the case is detected, i.e. whether there is still time to intervene. Previously the `mmr_window`/`ig_window` were compared against the index case's infectious-onset date and gated on the specific day a classmate contacted the index, so realistic windows (e.g. `mmr_window = 3`) did not behave as intended.
+
 * The models `ModelMeaslesMixing()` and `ModelMeaslesMixingRiskQuarantine()` no longer use `contact_rate`; instead, their `contact_matrix` stores the expected number of contacts between groups. Calibration can now be done with the new function `calibrate_mixing_model()`.
 
 * Updated the documentation, examples, and contact-matrix helpers for the mixing models so they consistently treat `contact_matrix` as the full contact-rate matrix.

--- a/R/InterventionMeaslesPEP.R
+++ b/R/InterventionMeaslesPEP.R
@@ -17,6 +17,11 @@
 #' @param ig_window Time window for immunoglobulin (IG) administration.
 #' @param target_states,states_if_pep_effective,states_if_pep_ineffective
 #' Integer vectors of target and destination states (see details).
+#' @param agent_groups Optional integer vector of group (e.g. classroom)
+#' membership, with one entry per agent, in agent order. When supplied, PEP is
+#' offered only within the group(s) of the identified case(s). Defaults to
+#' `integer(0)`, meaning the whole population is treated as a single exposed
+#' group (see details).
 #'
 #' @details
 #' This functions creates a global event that represents a post-exposure
@@ -56,6 +61,25 @@
 #' from the agent, and they are again eligible for PEP if they
 #' are exposed again.
 #'
+#' # Who is offered PEP
+#'
+#' Public health rarely has time to trace individual contacts. When a case is
+#' identified, the exposed group is treated as exposed as a whole, and the only
+#' question is how long ago that exposure started. By default that group is the
+#' entire population, which is appropriate for a single classroom but
+#' misleading when the population is really a set of separate communities.
+#'
+#' `agent_groups` circumscribes the response. Supply one group label per agent,
+#' in agent order, and PEP is offered only to agents sharing the label of an
+#' identified case. Labels are arbitrary integers: agents with the same label
+#' are in the same group. For example, with 60 agents in three classrooms,
+#' `agent_groups = rep(1:3, each = 20)`. A vector whose length is neither zero
+#' nor the number of agents is an error, since it is matched to agents by
+#' position.
+#'
+#' Each group is also timed from its own exposure, so a case identified in one
+#' classroom does not shorten (or extend) the window available to another.
+#'
 #' @returns
 #' An object of class `epiworld_globalevent` representing the measles PEP
 #' intervention.
@@ -73,7 +97,8 @@ InterventionMeaslesPEP <- function(
   ig_window,
   target_states,
   states_if_pep_effective,
-  states_if_pep_ineffective
+  states_if_pep_ineffective,
+  agent_groups = integer(0)
 ) {
 
   stopifnot_character(name)
@@ -88,6 +113,12 @@ InterventionMeaslesPEP <- function(
   stopifnot_int(states_if_pep_effective, lb = 0)
   stopifnot_int(states_if_pep_ineffective, lb = 0)
 
+  # Labels are arbitrary, so no bounds. The length is only checked against
+  # the model when the intervention first runs, since the number of agents
+  # is not known here.
+  if (length(agent_groups))
+    stopifnot_int(agent_groups)
+
   InterventionMeaslesPEP_cpp(
     name,
     mmr_efficacy,
@@ -100,7 +131,8 @@ InterventionMeaslesPEP <- function(
     ig_window,
     target_states,
     states_if_pep_effective,
-    states_if_pep_ineffective
+    states_if_pep_ineffective,
+    as.integer(agent_groups)
   ) |>
     structure(class = c("epiworld_globalevent"))
 

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -16,6 +16,6 @@ ModelMeaslesMixingRiskQuarantine_cpp <- function(n, prevalence, transmission_rat
   .Call(`_measles_ModelMeaslesMixingRiskQuarantine_cpp`, n, prevalence, transmission_rate, vax_efficacy, incubation_period, prodromal_period, rash_period, contact_matrix, hospitalization_rate, hospitalization_period, days_undetected, quarantine_period_high, quarantine_period_medium, quarantine_period_low, quarantine_willingness, isolation_willingness, isolation_period, prop_vaccinated, detection_rate_quarantine, contact_tracing_success_rate, contact_tracing_days_window)
 }
 
-InterventionMeaslesPEP_cpp <- function(name, mmr_efficacy, ig_efficacy, ig_half_life_mean, ig_half_life_sd, mmr_willingness, ig_willingness, mmr_window, ig_window, target_states, states_if_pep_effective, states_if_pep_ineffective) {
-  .Call(`_measles_InterventionMeaslesPEP_cpp`, name, mmr_efficacy, ig_efficacy, ig_half_life_mean, ig_half_life_sd, mmr_willingness, ig_willingness, mmr_window, ig_window, target_states, states_if_pep_effective, states_if_pep_ineffective)
+InterventionMeaslesPEP_cpp <- function(name, mmr_efficacy, ig_efficacy, ig_half_life_mean, ig_half_life_sd, mmr_willingness, ig_willingness, mmr_window, ig_window, target_states, states_if_pep_effective, states_if_pep_ineffective, agent_groups) {
+  .Call(`_measles_InterventionMeaslesPEP_cpp`, name, mmr_efficacy, ig_efficacy, ig_half_life_mean, ig_half_life_sd, mmr_willingness, ig_willingness, mmr_window, ig_window, target_states, states_if_pep_effective, states_if_pep_ineffective, agent_groups)
 }

--- a/inst/include/measles/interventionmeaslespep-bones.hpp
+++ b/inst/include/measles/interventionmeaslespep-bones.hpp
@@ -37,6 +37,23 @@ private:
     std::vector< int > _states_if_pep_effective;
     std::vector< int > _states_if_pep_ineffective;
 
+    // Group (e.g. classroom) each agent belongs to. Either empty, meaning
+    // the whole population is treated as a single exposed group, or one
+    // entry per agent, indexed by agent id.
+    std::vector< int > _agent_groups;
+
+    /**
+     * @brief Group an agent belongs to.
+     * @details
+     * When no groups were specified the whole population is treated as a
+     * single group, so that the grouped and ungrouped cases follow the
+     * same code path.
+     */
+    int _group_of(size_t agent_id) const {
+        return this->_agent_groups.empty() ?
+            0 : this->_agent_groups[agent_id];
+    }
+
     // Id of the model
     int model_id = -1;
 
@@ -74,6 +91,13 @@ public:
      * 5 if they receive PEP, then `quarantine_states` should include 2 and
      * `quarantine_states_for_pep` should include 5 at the corresponding
      * position.
+     * @param agent_groups Optional group (e.g. classroom) membership, one
+     * entry per agent, indexed by agent id. When a case is identified, PEP
+     * is offered only within the group(s) the identified case(s) belong to.
+     * Group labels are arbitrary integers; agents sharing a label are in
+     * the same group. If empty (the default), the whole population is
+     * treated as a single exposed group and PEP is offered to everyone.
+     * Must be either empty or of length `Model::size()`.
      */
     InterventionMeaslesPEP(
         std::string name,
@@ -87,7 +111,8 @@ public:
         epiworld_double ig_window,
         std::vector< int > target_states,
         std::vector< int > states_if_pep_effective,
-        std::vector< int > states_if_pep_ineffective
+        std::vector< int > states_if_pep_ineffective,
+        std::vector< int > agent_groups = {}
     );
 
     /**
@@ -96,9 +121,13 @@ public:
      * This function is called at the end of the day as a global event. It
      * iterates through the agents and gives PEP to those who are willing and
      * applicable.
-     * 
+     *
      * Agents who receive PEP may then be moved to a different state if
      * the PEP is effective.
+     *
+     * If groups were specified, only agents in the same group as an
+     * identified case are considered, and each group is timed from its own
+     * exposure.
      */
     void operator()(Model<TSeq> * model, int day) override;
 

--- a/inst/include/measles/interventionmeaslespep-meat.hpp
+++ b/inst/include/measles/interventionmeaslespep-meat.hpp
@@ -122,7 +122,9 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
             "The InterventionMeaslesPEP global event can only be used with "
             "models that inherit from QuarantineTrigger. This is because the "
             "intervention relies on the quarantine triggering mechanism to "
-            "identify which agents should receive PEP."
+            "learn which cases were identified today, and the day public "
+            "health considers each of them to have become infectious, which "
+            "is what dates the exposure."
         );
     }
 
@@ -201,30 +203,48 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
 
         size_t agent_id = cases[t_i];
 
-        auto n_contacts = contact_trace.get_n_contacts(agent_id);
-        if (n_contacts == 0)
+        auto n_recorded = contact_trace.get_n_contacts(agent_id);
+        if (n_recorded == 0)
             continue;
 
-        if (n_contacts > contact_trace.get_max_contacts())
-            n_contacts = contact_trace.get_max_contacts();
-
         // Start of the infectious window as considered by public health:
-        // rash onset counted backwards by the prodromal period.
+        // rash onset counted backwards by the prodromal period. Nobody
+        // could have been exposed before the simulation began.
         int infectious_since = cases_infectious_since[t_i];
+        if (infectious_since < 0)
+            infectious_since = 0;
 
         // First day the class encountered this index while infectious.
+        //
+        // Contact tracing keeps only the most recent `max_contacts`
+        // encounters per agent, in a circular buffer. Once it has wrapped
+        // around, the earliest encounters have been overwritten, and the
+        // oldest one still on record is *later* than the true first
+        // encounter. Trusting it would shorten `days_since` and hand out
+        // PEP after the window had in fact closed. When we detect that
+        // loss we fall back to the date public health would use with no
+        // contact data at all: the infectious-onset date. That is the
+        // earliest the class could possibly have been exposed, so the
+        // fallback can only withhold PEP, never grant it too late.
         int index_first_seen = -1;
-        for (size_t i = 0u; i < n_contacts; ++i)
+        if (n_recorded > contact_trace.get_max_contacts())
         {
-            int contact_day = contact_trace.get_contact(agent_id, i).second;
+            index_first_seen = infectious_since;
+        }
+        else
+        {
+            for (size_t i = 0u; i < n_recorded; ++i)
+            {
+                int contact_day = contact_trace.get_contact(agent_id, i).second;
 
-            // Encounters before the index was considered infectious do
-            // not expose anyone.
-            if (contact_day < infectious_since)
-                continue;
+                // Encounters before the index was considered infectious do
+                // not expose anyone.
+                if (contact_day < infectious_since)
+                    continue;
 
-            if ((index_first_seen < 0) || (contact_day < index_first_seen))
-                index_first_seen = contact_day;
+                if ((index_first_seen < 0) || (contact_day < index_first_seen))
+                    index_first_seen = contact_day;
+            }
         }
 
         // This index never met the class while infectious (e.g. it was

--- a/inst/include/measles/interventionmeaslespep-meat.hpp
+++ b/inst/include/measles/interventionmeaslespep-meat.hpp
@@ -18,7 +18,8 @@ inline InterventionMeaslesPEP<TSeq>::InterventionMeaslesPEP(
     epiworld_double ig_window,
     std::vector< int > target_states,
     std::vector< int > states_if_pep_effective,
-    std::vector< int > states_if_pep_ineffective
+    std::vector< int > states_if_pep_ineffective,
+    std::vector< int > agent_groups
 ) {
 
     this->set_name(name);
@@ -37,6 +38,11 @@ inline InterventionMeaslesPEP<TSeq>::InterventionMeaslesPEP(
     this->_states_if_pep_effective = states_if_pep_effective;
     this->_states_if_pep_ineffective = states_if_pep_ineffective;
 
+    // An empty vector means "no groups": the whole population is treated
+    // as a single exposed group. Its length can only be checked against
+    // the model once we have one, so that happens in _setup().
+    this->_agent_groups = agent_groups;
+
     // Paramters
     this->_mmr_efficacy = mmr_efficacy;
     this->_ig_efficacy = ig_efficacy;
@@ -52,6 +58,21 @@ template<typename TSeq>
 inline void InterventionMeaslesPEP<TSeq>::_setup(
     Model<TSeq> * model
 ) {
+
+    // Groups are optional, but if given there must be one entry per agent
+    // (they are indexed by agent id).
+    if (
+        !this->_agent_groups.empty() &&
+        (this->_agent_groups.size() != model->size())
+    )
+        throw std::length_error(
+            "The vector of agent groups passed to InterventionMeaslesPEP "
+            "must be either empty (no groups: PEP is offered to the whole "
+            "population) or have one entry per agent. It currently has " +
+            std::to_string(this->_agent_groups.size()) +
+            " entries, but the model has " +
+            std::to_string(model->size()) + " agents."
+        );
 
     // Randomizing willingness
     this->_willing_to_receive_mmr.assign(model->size(), false);
@@ -196,8 +217,13 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
     // (e.g. via a global event) and the infectious window opens on a
     // Saturday, then the first actual encounter is the following Monday,
     // and Monday -- not Saturday -- anchors the MMR window.
+    //
+    // Each exposed group is dated separately: a case in one classroom
+    // says nothing about how long ago another classroom was exposed.
+    // When no groups were given every case falls into the same bucket,
+    // which is the whole-population behaviour.
     // -------------------------------------------------------------------
-    int first_seen = -1;
+    std::map< int, int > group_first_seen;
     for (size_t t_i = 0u; t_i < cases.size(); ++t_i)
     {
 
@@ -253,45 +279,72 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
         if (index_first_seen < 0)
             continue;
 
-        // When several cases are identified together, public health works
-        // from the earliest exposure: a co-detected case whose rash started
-        // earlier dictates how much time is left to intervene.
-        if ((first_seen < 0) || (index_first_seen < first_seen))
-            first_seen = index_first_seen;
+        // When several cases are identified together in the same group,
+        // public health works from the earliest exposure: a co-detected
+        // case whose rash started earlier dictates how much time is left
+        // to intervene.
+        int group = this->_group_of(agent_id);
+        auto group_i = group_first_seen.find(group);
+        if (
+            (group_i == group_first_seen.end()) ||
+            (index_first_seen < group_i->second)
+        )
+            group_first_seen[group] = index_first_seen;
 
     }
 
-    // No identified case actually exposed the class.
-    if (first_seen < 0)
-        return;
+    // Is there still time to intervene? Drop the groups whose window has
+    // already closed; what remains are the groups to offer PEP to.
+    for (auto group_i = group_first_seen.begin();
+         group_i != group_first_seen.end(); )
+    {
+        int days_since = model->today() - group_i->second;
 
-    // Is there still time to intervene? MMR is preferred while we are
-    // within its (shorter) window; otherwise IG is offered if we are
-    // within its window.
-    int days_since = model->today() - first_seen;
-    bool within_mmr_window =
-        (days_since >= 0) && (days_since <= pep_mmr_window);
-    bool within_ig_window =
-        (days_since >= 0) && (days_since <= pep_ig_window);
+        if (
+            (days_since < 0) ||
+            ((days_since > pep_mmr_window) && (days_since > pep_ig_window))
+        )
+            group_i = group_first_seen.erase(group_i);
+        else
+            ++group_i;
+    }
 
-    // Too late for both MMR and IG: nobody is offered PEP.
-    if (!within_mmr_window && !within_ig_window)
+    // Either no identified case actually exposed anyone, or it is too late
+    // for both MMR and IG everywhere: nobody is offered PEP.
+    if (group_first_seen.empty())
         return;
 
     // -------------------------------------------------------------------
-    // Step 2: offer PEP to the exposed group.
+    // Step 2: offer PEP to the exposed group(s).
     //
-    // We are not doing individual contact tracing: the entire school is
-    // assumed to have been exposed. Every agent still in a PEP-target
-    // state is therefore offered PEP, whether or not they were recorded
-    // as having met the index case. Agents who are already immune or
-    // otherwise ineligible are excluded by not being in a target state.
+    // We are not doing individual contact tracing: everyone in an exposed
+    // group is assumed to have been exposed. Every agent of that group
+    // still in a PEP-target state is therefore offered PEP, whether or not
+    // they were recorded as having met the index case. Agents who are
+    // already immune or otherwise ineligible are excluded by not being in
+    // a target state.
+    //
+    // Groups let this be narrowed to, say, the classroom the identified
+    // case belongs to. Without them the exposed group is the entire
+    // population.
     // -------------------------------------------------------------------
     auto & tool_mmr = model->get_tool("PEP MMR");
     auto & tool_ig  = model->get_tool("PEP IG");
 
     for (size_t agent_i = 0u; agent_i < model->size(); ++agent_i)
     {
+
+        // Was this agent's group exposed by a case identified today, and
+        // is that exposure still recent enough to act on?
+        auto group_i = group_first_seen.find(this->_group_of(agent_i));
+        if (group_i == group_first_seen.end())
+            continue;
+
+        // MMR is preferred while we are within its (shorter) window;
+        // otherwise IG is offered if we are within its window.
+        int days_since = model->today() - group_i->second;
+        bool within_mmr_window = (days_since <= pep_mmr_window);
+        bool within_ig_window  = (days_since <= pep_ig_window);
 
         auto & agent = model->get_agent(agent_i);
 

--- a/inst/include/measles/interventionmeaslespep-meat.hpp
+++ b/inst/include/measles/interventionmeaslespep-meat.hpp
@@ -133,33 +133,74 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
         this->_setup(model);
     }
 
+
     // Common variables
     int pep_mmr_window = static_cast<int>(model->par(this->_par_pep_mmr_window));
     int pep_ig_window = static_cast<int>(model->par(this->_par_pep_ig_window)); 
 
-    // Getting the list of agents that triggered the
-    // quarantine
+    auto & contact_trace = model->get_contact_tracing();
+
+    // Getting the list of agents that triggered the quarantine, together
+    // with the day public health considers each of them to have become
+    // infectious.
+    //
+    // This global event runs every day, but the triggering set is only
+    // refreshed when a case is actually identified. We therefore treat it
+    // as a queue of detections to respond to: today's detections are taken
+    // and the queue emptied, so that a detection is not answered with a
+    // second round of PEP on every subsequent day.
     auto & triggering_agents = quarantine_trigger_ptr->get_triggering_agents();
-    auto & contact_trace     = model->get_contact_tracing();
-    
-    // When does pub health consider the agent to be infectious
     auto & date_infectious   = quarantine_trigger_ptr->get_date_infectious();
+
+    if (triggering_agents.empty())
+        return;
+
+    std::vector< size_t > cases(triggering_agents);
+    std::vector< int > cases_infectious_since(date_infectious);
+
+    triggering_agents.clear();
+    date_infectious.clear();
 
     // Making room (we will iterate this vectors
     // later to figure out the state changes.)
     _to_receive_pep.clear();
     _next_if_effective.clear();
     _next_if_ineffective.clear();
-    for (size_t t_i = 0u; t_i < triggering_agents.size(); ++t_i)
+
+    // -------------------------------------------------------------------
+    // Step 1: date the exposure.
+    //
+    // Public health does not have the time to trace individual contacts.
+    // When a case is identified they look at the group that was exposed
+    // (here, the whole school) and ask how long ago that exposure started,
+    // since MMR/IG must be given within a few days *of the exposure*.
+    //
+    // Given an index case with rash onset on day `d`, public health
+    // considers it infectious from `d - prodromal_period` onwards (that is
+    // `date_infectious`, computed by the model). The reference date is
+    // then the FIRST day, on or after that, on which the class actually
+    // encountered the index:
+    //
+    //                first_seen
+    //                v
+    //   |------------|=====================|.............| today
+    //   ^            (index in school and infectious)     (case detected)
+    //   infectious_since
+    //                |<-------- days_since = today - first_seen -------->|
+    //
+    // Contact tracing is used only to *date* that first encounter, not to
+    // decide who was exposed. This matters when the class is not in
+    // session every day: if the contact rate is set to zero on weekends
+    // (e.g. via a global event) and the infectious window opens on a
+    // Saturday, then the first actual encounter is the following Monday,
+    // and Monday -- not Saturday -- anchors the MMR window.
+    // -------------------------------------------------------------------
+    int first_seen = -1;
+    for (size_t t_i = 0u; t_i < cases.size(); ++t_i)
     {
 
-        size_t agent_id = triggering_agents[t_i];
+        size_t agent_id = cases[t_i];
 
-        // Contacts of the (infectious) index case: these are the
-        // classmates that shared the classroom while the index was
-        // infectious. We do not care whether a given classmate
-        // *specifically* interacted with the index; being in school
-        // during the infectious window is what matters.
         auto n_contacts = contact_trace.get_n_contacts(agent_id);
         if (n_contacts == 0)
             continue;
@@ -167,121 +208,121 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
         if (n_contacts > contact_trace.get_max_contacts())
             n_contacts = contact_trace.get_max_contacts();
 
-        // Precapturing the tools
-        auto & tool_mmr = model->get_tool("PEP MMR");
-        auto & tool_ig  = model->get_tool("PEP IG");
+        // Start of the infectious window as considered by public health:
+        // rash onset counted backwards by the prodromal period.
+        int infectious_since = cases_infectious_since[t_i];
 
-        // (a) Start of the infectious window as considered by public
-        // health: rash onset counted backwards by the prodromal period.
-        int infectious_since = date_infectious[t_i];
-
-        // (b) Last time the class saw the index while infectious.
-        //
-        //   infectious window                 today (case detected)
-        //  |=================|.....................|
-        //  ^                 ^
-        //  infectious_since  last_seen
-        //                    (last day the class saw the index)
-        //          |<------ days_since ----->|
-        //
-        // PEP is only worthwhile while `days_since = today - last_seen`
-        // is within the MMR (~3 day) or IG (~6 day) window. The reference
-        // is the *last* time the class was exposed, not the day the index
-        // became infectious.
-        int last_seen = -1;
+        // First day the class encountered this index while infectious.
+        int index_first_seen = -1;
         for (size_t i = 0u; i < n_contacts; ++i)
         {
             int contact_day = contact_trace.get_contact(agent_id, i).second;
 
+            // Encounters before the index was considered infectious do
+            // not expose anyone.
             if (contact_day < infectious_since)
                 continue;
 
-            if (contact_day > last_seen)
-                last_seen = contact_day;
+            if ((index_first_seen < 0) || (contact_day < index_first_seen))
+                index_first_seen = contact_day;
         }
 
-        // No exposure recorded within the infectious window.
-        if (last_seen < 0)
+        // This index never met the class while infectious (e.g. it was
+        // never in school during its infectious window), so it exposed
+        // nobody.
+        if (index_first_seen < 0)
             continue;
 
-        // (e) Is there still time to intervene? This is a class-level
-        // decision: it depends on how long ago the class was last
-        // exposed, not on any single contact.
-        int days_since = model->today() - last_seen;
-        bool within_mmr_window =
-            (days_since >= 0) && (days_since <= pep_mmr_window);
-        bool within_ig_window =
-            (days_since >= 0) && (days_since <= pep_ig_window);
+        // When several cases are identified together, public health works
+        // from the earliest exposure: a co-detected case whose rash started
+        // earlier dictates how much time is left to intervene.
+        if ((first_seen < 0) || (index_first_seen < first_seen))
+            first_seen = index_first_seen;
 
-        // Too late for both MMR and IG: nobody in this cohort is offered
-        // PEP.
-        if (!within_mmr_window && !within_ig_window)
+    }
+
+    // No identified case actually exposed the class.
+    if (first_seen < 0)
+        return;
+
+    // Is there still time to intervene? MMR is preferred while we are
+    // within its (shorter) window; otherwise IG is offered if we are
+    // within its window.
+    int days_since = model->today() - first_seen;
+    bool within_mmr_window =
+        (days_since >= 0) && (days_since <= pep_mmr_window);
+    bool within_ig_window =
+        (days_since >= 0) && (days_since <= pep_ig_window);
+
+    // Too late for both MMR and IG: nobody is offered PEP.
+    if (!within_mmr_window && !within_ig_window)
+        return;
+
+    // -------------------------------------------------------------------
+    // Step 2: offer PEP to the exposed group.
+    //
+    // We are not doing individual contact tracing: the entire school is
+    // assumed to have been exposed. Every agent still in a PEP-target
+    // state is therefore offered PEP, whether or not they were recorded
+    // as having met the index case. Agents who are already immune or
+    // otherwise ineligible are excluded by not being in a target state.
+    // -------------------------------------------------------------------
+    auto & tool_mmr = model->get_tool("PEP MMR");
+    auto & tool_ig  = model->get_tool("PEP IG");
+
+    for (size_t agent_i = 0u; agent_i < model->size(); ++agent_i)
+    {
+
+        auto & agent = model->get_agent(agent_i);
+
+        // Is the agent eligible for PEP?
+        int agent_state = static_cast<int>(agent.get_state());
+        if (!IN(agent_state, this->_target_states))
             continue;
 
-        // Offering PEP to the exposed classmates. Each classmate is
-        // considered at most once, regardless of how many times they
-        // shared the classroom with the index.
-        std::set< size_t > processed;
-        for (size_t i = 0u; i < n_contacts; ++i)
+        // Already under prophylaxis: there is nothing to add by dosing
+        // again, and willingness is fixed, so re-offering would not change
+        // the agent's decision. Note that IG wanes and is removed once its
+        // duration is over, at which point the agent becomes eligible again.
+        if (agent.has_tool("PEP MMR") || agent.has_tool("PEP IG"))
+            continue;
+
+        // Willingness to receive each of the two prophylaxes.
+        if (within_mmr_window && this->_willing_to_receive_mmr[agent_i])
         {
-            auto [contact_id, contact_day] =
-                contact_trace.get_contact(agent_id, i);
-
-            // Only classmates present during the infectious window.
-            if (contact_day < infectious_since)
-                continue;
-
-            // Consider each classmate once.
-            if (!processed.insert(contact_id).second)
-                continue;
-
-            auto & contact = model->get_agent(contact_id);
-
-            // First question: Is the classmate eligible for PEP?
-            int contact_state = static_cast<int>(contact.get_state());
-            if (!IN(contact_state, this->_target_states))
-                continue;
-
-            // (c)/(d) Vaccination status and willingness. MMR is
-            // preferred while we are within its (shorter) window;
-            // otherwise IG is offered if we are within its window.
-            if (within_mmr_window && this->_willing_to_receive_mmr[contact_id])
-            {
-                // We will administer MMR PEP to the agent
-                contact.add_tool(
-                    *model,
-                    tool_mmr
-                );
-            }
-            else if (within_ig_window && this->_willing_to_receive_ig[contact_id])
-            {
-                // We will administer IG PEP to the agent
-                contact.add_tool(
-                    *model,
-                    tool_ig
-                );
-            }
-            // Nothing happens
-            else
-                continue;
-
-            // Finding the corresponding state for PEP
-            auto it = std::find(
-                this->_target_states.begin(),
-                this->_target_states.end(),
-                contact_state
+            // We will administer MMR PEP to the agent
+            agent.add_tool(
+                *model,
+                tool_mmr
             );
-
-            // No need to check it, we know it is there
-            auto pos = std::distance(this->_target_states.begin(), it);
-
-            // Recording the information of the agent
-            // so we can decide to what state to move
-            _to_receive_pep.push_back(contact.get_id());
-            _next_if_effective.push_back(_states_if_pep_effective[pos]);
-            _next_if_ineffective.push_back(_states_if_pep_ineffective[pos]);
-
         }
+        else if (within_ig_window && this->_willing_to_receive_ig[agent_i])
+        {
+            // We will administer IG PEP to the agent
+            agent.add_tool(
+                *model,
+                tool_ig
+            );
+        }
+        // Nothing happens
+        else
+            continue;
+
+        // Finding the corresponding state for PEP
+        auto it = std::find(
+            this->_target_states.begin(),
+            this->_target_states.end(),
+            agent_state
+        );
+
+        // No need to check it, we know it is there
+        auto pos = std::distance(this->_target_states.begin(), it);
+
+        // Recording the information of the agent
+        // so we can decide to what state to move
+        _to_receive_pep.push_back(agent.get_id());
+        _next_if_effective.push_back(_states_if_pep_effective[pos]);
+        _next_if_ineffective.push_back(_states_if_pep_ineffective[pos]);
 
     }
 

--- a/inst/include/measles/interventionmeaslespep-meat.hpp
+++ b/inst/include/measles/interventionmeaslespep-meat.hpp
@@ -140,8 +140,10 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
     // Getting the list of agents that triggered the
     // quarantine
     auto & triggering_agents = quarantine_trigger_ptr->get_triggering_agents();
-    auto & contact_trace = model->get_contact_tracing();
-    auto & date_infectious = quarantine_trigger_ptr->get_date_infectious();
+    auto & contact_trace     = model->get_contact_tracing();
+    
+    // When does pub health consider the agent to be infectious
+    auto & date_infectious   = quarantine_trigger_ptr->get_date_infectious();
 
     // Making room (we will iterate this vectors
     // later to figure out the state changes.)
@@ -153,12 +155,15 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
 
         size_t agent_id = triggering_agents[t_i];
 
-        // Checking if the agent has made a contact
+        // Contacts of the (infectious) index case: these are the
+        // classmates that shared the classroom while the index was
+        // infectious. We do not care whether a given classmate
+        // *specifically* interacted with the index; being in school
+        // during the infectious window is what matters.
         auto n_contacts = contact_trace.get_n_contacts(agent_id);
         if (n_contacts == 0)
             continue;
 
-        // Iterating over the contacts
         if (n_contacts > contact_trace.get_max_contacts())
             n_contacts = contact_trace.get_max_contacts();
 
@@ -166,25 +171,81 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
         auto & tool_mmr = model->get_tool("PEP MMR");
         auto & tool_ig  = model->get_tool("PEP IG");
 
-        // Get the relevant window
+        // (a) Start of the infectious window as considered by public
+        // health: rash onset counted backwards by the prodromal period.
         int infectious_since = date_infectious[t_i];
+
+        // (b) Last time the class saw the index while infectious.
+        //
+        //   infectious window                 today (case detected)
+        //  |=================|.....................|
+        //  ^                 ^
+        //  infectious_since  last_seen
+        //                    (last day the class saw the index)
+        //          |<------ days_since ----->|
+        //
+        // PEP is only worthwhile while `days_since = today - last_seen`
+        // is within the MMR (~3 day) or IG (~6 day) window. The reference
+        // is the *last* time the class was exposed, not the day the index
+        // became infectious.
+        int last_seen = -1;
         for (size_t i = 0u; i < n_contacts; ++i)
         {
-            // Relevant contact
-            auto [contact_id, contact_day] = contact_trace.get_contact(agent_id, i);
+            int contact_day = contact_trace.get_contact(agent_id, i).second;
+
+            if (contact_day < infectious_since)
+                continue;
+
+            if (contact_day > last_seen)
+                last_seen = contact_day;
+        }
+
+        // No exposure recorded within the infectious window.
+        if (last_seen < 0)
+            continue;
+
+        // (e) Is there still time to intervene? This is a class-level
+        // decision: it depends on how long ago the class was last
+        // exposed, not on any single contact.
+        int days_since = model->today() - last_seen;
+        bool within_mmr_window =
+            (days_since >= 0) && (days_since <= pep_mmr_window);
+        bool within_ig_window =
+            (days_since >= 0) && (days_since <= pep_ig_window);
+
+        // Too late for both MMR and IG: nobody in this cohort is offered
+        // PEP.
+        if (!within_mmr_window && !within_ig_window)
+            continue;
+
+        // Offering PEP to the exposed classmates. Each classmate is
+        // considered at most once, regardless of how many times they
+        // shared the classroom with the index.
+        std::set< size_t > processed;
+        for (size_t i = 0u; i < n_contacts; ++i)
+        {
+            auto [contact_id, contact_day] =
+                contact_trace.get_contact(agent_id, i);
+
+            // Only classmates present during the infectious window.
+            if (contact_day < infectious_since)
+                continue;
+
+            // Consider each classmate once.
+            if (!processed.insert(contact_id).second)
+                continue;
+
             auto & contact = model->get_agent(contact_id);
 
-            // First question: Is the agent elegible for PEP?
+            // First question: Is the classmate eligible for PEP?
             int contact_state = static_cast<int>(contact.get_state());
             if (!IN(contact_state, this->_target_states))
                 continue;
 
-            // Second question: Is the agent within the MMR window?
-            if (
-                this->_willing_to_receive_mmr[contact_id] &&
-                (contact_day > infectious_since) &&
-                ((contact_day - infectious_since) <= pep_mmr_window)
-            )
+            // (c)/(d) Vaccination status and willingness. MMR is
+            // preferred while we are within its (shorter) window;
+            // otherwise IG is offered if we are within its window.
+            if (within_mmr_window && this->_willing_to_receive_mmr[contact_id])
             {
                 // We will administer MMR PEP to the agent
                 contact.add_tool(
@@ -192,11 +253,7 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
                     tool_mmr
                 );
             }
-            else if (
-                this->_willing_to_receive_ig[contact_id] &&
-                (contact_day > infectious_since) &&
-                ((contact_day - infectious_since) <= pep_ig_window)
-            )
+            else if (within_ig_window && this->_willing_to_receive_ig[contact_id])
             {
                 // We will administer IG PEP to the agent
                 contact.add_tool(
@@ -212,7 +269,7 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
             auto it = std::find(
                 this->_target_states.begin(),
                 this->_target_states.end(),
-                contact.get_state()
+                contact_state
             );
 
             // No need to check it, we know it is there
@@ -223,7 +280,7 @@ inline void InterventionMeaslesPEP<TSeq>::operator()(Model<TSeq> * model, int) {
             _to_receive_pep.push_back(contact.get_id());
             _next_if_effective.push_back(_states_if_pep_effective[pos]);
             _next_if_ineffective.push_back(_states_if_pep_ineffective[pos]);
-            
+
         }
 
     }

--- a/man/InterventionMeaslesPEP.Rd
+++ b/man/InterventionMeaslesPEP.Rd
@@ -16,7 +16,8 @@ InterventionMeaslesPEP(
   ig_window,
   target_states,
   states_if_pep_effective,
-  states_if_pep_ineffective
+  states_if_pep_ineffective,
+  agent_groups = integer(0)
 )
 }
 \arguments{
@@ -43,6 +44,12 @@ immunoglobulin (IG).}
 \item{ig_window}{Time window for immunoglobulin (IG) administration.}
 
 \item{target_states, states_if_pep_effective, states_if_pep_ineffective}{Integer vectors of target and destination states (see details).}
+
+\item{agent_groups}{Optional integer vector of group (e.g. classroom)
+membership, with one entry per agent, in agent order. When supplied, PEP is
+offered only within the group(s) of the identified case(s). Defaults to
+\code{integer(0)}, meaning the whole population is treated as a single exposed
+group (see details).}
 }
 \value{
 An object of class \code{epiworld_globalevent} representing the measles PEP
@@ -87,6 +94,25 @@ distribution with mean \code{ig_half_life_mean} and standard deviation
 from the agent, and they are again eligible for PEP if they
 are exposed again.
 }
+\section{Who is offered PEP}{
+Public health rarely has time to trace individual contacts. When a case is
+identified, the exposed group is treated as exposed as a whole, and the only
+question is how long ago that exposure started. By default that group is the
+entire population, which is appropriate for a single classroom but
+misleading when the population is really a set of separate communities.
+
+\code{agent_groups} circumscribes the response. Supply one group label per agent,
+in agent order, and PEP is offered only to agents sharing the label of an
+identified case. Labels are arbitrary integers: agents with the same label
+are in the same group. For example, with 60 agents in three classrooms,
+\code{agent_groups = rep(1:3, each = 20)}. A vector whose length is neither zero
+nor the number of agents is an error, since it is matched to agents by
+position.
+
+Each group is also timed from its own exposure, so a case identified in one
+classroom does not shorten (or extend) the window available to another.
+}
+
 \seealso{
 \link[epiworldR:global-events]{epiworldR::global-events}
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -34,16 +34,16 @@ extern "C" SEXP _measles_ModelMeaslesMixingRiskQuarantine_cpp(SEXP n, SEXP preva
   END_CPP11
 }
 // interventions.cpp
-SEXP InterventionMeaslesPEP_cpp(std::string name, double mmr_efficacy, double ig_efficacy, double ig_half_life_mean, double ig_half_life_sd, double mmr_willingness, double ig_willingness, double mmr_window, double ig_window, std::vector< int > target_states, std::vector< int > states_if_pep_effective, std::vector< int > states_if_pep_ineffective);
-extern "C" SEXP _measles_InterventionMeaslesPEP_cpp(SEXP name, SEXP mmr_efficacy, SEXP ig_efficacy, SEXP ig_half_life_mean, SEXP ig_half_life_sd, SEXP mmr_willingness, SEXP ig_willingness, SEXP mmr_window, SEXP ig_window, SEXP target_states, SEXP states_if_pep_effective, SEXP states_if_pep_ineffective) {
+SEXP InterventionMeaslesPEP_cpp(std::string name, double mmr_efficacy, double ig_efficacy, double ig_half_life_mean, double ig_half_life_sd, double mmr_willingness, double ig_willingness, double mmr_window, double ig_window, std::vector< int > target_states, std::vector< int > states_if_pep_effective, std::vector< int > states_if_pep_ineffective, std::vector< int > agent_groups);
+extern "C" SEXP _measles_InterventionMeaslesPEP_cpp(SEXP name, SEXP mmr_efficacy, SEXP ig_efficacy, SEXP ig_half_life_mean, SEXP ig_half_life_sd, SEXP mmr_willingness, SEXP ig_willingness, SEXP mmr_window, SEXP ig_window, SEXP target_states, SEXP states_if_pep_effective, SEXP states_if_pep_ineffective, SEXP agent_groups) {
   BEGIN_CPP11
-    return cpp11::as_sexp(InterventionMeaslesPEP_cpp(cpp11::as_cpp<cpp11::decay_t<std::string>>(name), cpp11::as_cpp<cpp11::decay_t<double>>(mmr_efficacy), cpp11::as_cpp<cpp11::decay_t<double>>(ig_efficacy), cpp11::as_cpp<cpp11::decay_t<double>>(ig_half_life_mean), cpp11::as_cpp<cpp11::decay_t<double>>(ig_half_life_sd), cpp11::as_cpp<cpp11::decay_t<double>>(mmr_willingness), cpp11::as_cpp<cpp11::decay_t<double>>(ig_willingness), cpp11::as_cpp<cpp11::decay_t<double>>(mmr_window), cpp11::as_cpp<cpp11::decay_t<double>>(ig_window), cpp11::as_cpp<cpp11::decay_t<std::vector< int >>>(target_states), cpp11::as_cpp<cpp11::decay_t<std::vector< int >>>(states_if_pep_effective), cpp11::as_cpp<cpp11::decay_t<std::vector< int >>>(states_if_pep_ineffective)));
+    return cpp11::as_sexp(InterventionMeaslesPEP_cpp(cpp11::as_cpp<cpp11::decay_t<std::string>>(name), cpp11::as_cpp<cpp11::decay_t<double>>(mmr_efficacy), cpp11::as_cpp<cpp11::decay_t<double>>(ig_efficacy), cpp11::as_cpp<cpp11::decay_t<double>>(ig_half_life_mean), cpp11::as_cpp<cpp11::decay_t<double>>(ig_half_life_sd), cpp11::as_cpp<cpp11::decay_t<double>>(mmr_willingness), cpp11::as_cpp<cpp11::decay_t<double>>(ig_willingness), cpp11::as_cpp<cpp11::decay_t<double>>(mmr_window), cpp11::as_cpp<cpp11::decay_t<double>>(ig_window), cpp11::as_cpp<cpp11::decay_t<std::vector< int >>>(target_states), cpp11::as_cpp<cpp11::decay_t<std::vector< int >>>(states_if_pep_effective), cpp11::as_cpp<cpp11::decay_t<std::vector< int >>>(states_if_pep_ineffective), cpp11::as_cpp<cpp11::decay_t<std::vector< int >>>(agent_groups)));
   END_CPP11
 }
 
 extern "C" {
 static const R_CallMethodDef CallEntries[] = {
-    {"_measles_InterventionMeaslesPEP_cpp",           (DL_FUNC) &_measles_InterventionMeaslesPEP_cpp,           12},
+    {"_measles_InterventionMeaslesPEP_cpp",           (DL_FUNC) &_measles_InterventionMeaslesPEP_cpp,           13},
     {"_measles_ModelMeaslesMixingRiskQuarantine_cpp", (DL_FUNC) &_measles_ModelMeaslesMixingRiskQuarantine_cpp, 21},
     {"_measles_ModelMeaslesMixing_cpp",               (DL_FUNC) &_measles_ModelMeaslesMixing_cpp,               20},
     {"_measles_ModelMeaslesSchool_cpp",               (DL_FUNC) &_measles_ModelMeaslesSchool_cpp,               16},

--- a/src/interventions.cpp
+++ b/src/interventions.cpp
@@ -20,7 +20,8 @@ SEXP InterventionMeaslesPEP_cpp(
     double ig_window,
     std::vector< int > target_states,
     std::vector< int > states_if_pep_effective,
-    std::vector< int > states_if_pep_ineffective
+    std::vector< int > states_if_pep_ineffective,
+    std::vector< int > agent_groups
 ) {
 
   cpp11::external_pointer<measles::InterventionMeaslesPEP<>> ptr(
@@ -36,7 +37,8 @@ SEXP InterventionMeaslesPEP_cpp(
           ig_window,
           target_states,
           states_if_pep_effective,
-          states_if_pep_ineffective
+          states_if_pep_ineffective,
+          agent_groups
       )
   );
 


### PR DESCRIPTION
## What

Syncs the revised `InterventionMeaslesPEP` from epiworld (UofUEpiBio/epiworld#253) into `inst/include/measles/`, and documents the change in `NEWS.md`.

## Why

The PEP timelines were wrong. `mmr_window`/`ig_window` were compared against the index case's infectious-onset date and gated on the specific day a given classmate met the index, so a realistic `mmr_window = 3` did not behave as intended.

## What changed

**Dating the exposure.** The window now runs from the exposure to the day the case is identified — whether there is still time to intervene. The reference is the **first** day the school encountered the index case on or after its infectious-onset date (rash onset minus the prodromal period). Contact tracing is used only to date that first encounter, so if the contact rate is zeroed out on some days (e.g. weekends, via a global event) the first day actually in session anchors the window.

**Several cases at once.** The earliest of those first encounters applies.

**The exposed cohort.** PEP is offered to the whole school rather than only the index case's recorded contacts, reflecting that public health treats the exposed group as exposed instead of tracing individual contacts. Agents already holding a PEP tool are not dosed again; IG still wanes, after which they become eligible once more.

**Repeat administration.** Fixes PEP being re-administered every day after a case was identified (the triggering set was only refreshed on detection, so quiet days kept answering an old detection).

## Compatibility

The fix is contained in the vendored measles headers, so this builds against the **current** epiworldR — no epiworld core change and no epiworldR release is required. Verified by compiling `src/interventions.cpp` against the installed epiworldR headers.

## Verification

- `R CMD INSTALL` succeeds; the model runs end-to-end.
- Window gating works in R: with `mmr_window = ig_window = 0` or `1` there are no effective-PEP recoveries, and PEP takes effect from `3` upwards.
- At realistic settings (`mmr_window = 3`, `ig_window = 6`, willingness 0.8) quarantine still binds normally (738 `Quarantined Susceptible -> Susceptible` transitions) alongside effective-PEP recoveries.

## Note

This is a behaviour change: PEP is now considerably more widely administered and outbreak sizes are correspondingly smaller (upstream, average recipients go from ~60 to ~898 and mean outbreak size from 32.6 to 24.0). Results calibrated against previous versions will shift.

Upstream PR: UofUEpiBio/epiworld#253

## New: `agent_groups`

PEP was always offered to the whole population — right for a single classroom, misleading when the population is really a set of separate communities.

`InterventionMeaslesPEP()` gains an optional `agent_groups` argument: one group label per agent, in agent order.

```r
# 60 agents in three classrooms
InterventionMeaslesPEP(..., agent_groups = rep(1:3, each = 20))
```

PEP is then offered only to agents sharing a label with an identified case, and each group is timed from its own exposure, so a case identified in one classroom no longer shortens the window available to another. Labels are arbitrary integers; only equality matters.

The default, `integer(0)`, keeps the whole-population behaviour unchanged. A vector whose length is neither zero nor the number of agents raises a clear error when the intervention first runs (the model size is not known at construction time):

```
The vector of agent groups passed to InterventionMeaslesPEP must be either empty
(no groups: PEP is offered to the whole population) or have one entry per agent.
It currently has 10 entries, but the model has 900 agents.
```

Verified end-to-end: with 900 agents split into 30 classrooms, effective-PEP recoveries drop from 4 (whole population) to 2 (per classroom) at identical seed and parameters.

Upstream: UofUEpiBio/epiworld#253 (see `tests/14j-measles-pep-groups.cpp`).
